### PR TITLE
Task 5: Creating Cyclebreaking Algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+reset.sh

--- a/graph/ordering.go
+++ b/graph/ordering.go
@@ -25,10 +25,10 @@ func (tl *Ordering) HasCycles() *list.List {
 	for tname := range tl.AllTables {
 		visited[tname] = false
 	}
-
+	topologicalNodes := GetTopologicalNodes(tl.AllTables, tl.AllRelations)
 	for tableName := range visited {
-		newCycles, localVisited := tl.findCycles(tableName) // find the cycles and the visited tables
-		cycles.PushBack(newCycles)                          // append the new list to the current one
+		newCycles, localVisited := tl.findCycles(tableName, topologicalNodes) // find the cycles and the visited tables
+		cycles.PushBackList(newCycles)                                        // append the new list to the current one
 		for local := range localVisited {
 			delete(visited, local) // delete visited tables since they have already been covered
 		}
@@ -38,14 +38,13 @@ func (tl *Ordering) HasCycles() *list.List {
 
 func (tl *Ordering) hasCyclesForTable(tableName string) *list.List {
 	// checks if there is a cycle in the path of a given table
-	cycles, _ := tl.findCycles(tableName)
+	cycles, _ := tl.findCycles(tableName, GetTopologicalNodes(tl.AllTables, tl.AllRelations))
 	return cycles
 }
 
-func (tl *Ordering) findCycles(tableName string) (*list.List, map[string]bool) {
+func (tl *Ordering) findCycles(tableName string, topologicalNodes map[string]*TopologicalNode) (*list.List, map[string]bool) {
 	var nextTable string
 	visited := make(map[string]bool) // map of tables we've visited
-	topologicalNodes := GetTopologicalNodes(tl.AllTables, tl.AllRelations)
 	node := topologicalNodes[tableName]
 	node.path = node.TableName
 	cycles := list.New()    // cycles list
@@ -135,5 +134,71 @@ func cleanCyclicPath(cString string) string {
 		}
 	}
 	// the first string is also the last so we cut the last string off to not have duplicates in string
-	return strings.Join(allTables[i:len(allTables)], " --> ")
+	return strings.Join(allTables[i:], " --> ")
+}
+func getTablesMap(cycles *list.List) map[string]map[string]bool {
+	m := make(map[string]map[string]bool)
+	node := cycles.Front()
+	for node != nil {
+		l := make(map[string]bool)
+		cycleArr := strings.Split(node.Value.(string), " --> ") // get the array of strings
+		for i := 0; i < len(cycleArr)-1; i++ {                  // we skip the last since it's a duplicate of the first
+			table := cycleArr[i]
+			l[table] = true // add the table to the map
+		}
+		m[node.Value.(string)] = l // set the array
+		node = node.Next()         // move to the next
+	}
+	return m
+}
+
+func getFrequency(cycles *list.List) map[string]int {
+	m := make(map[string]int)
+	node := cycles.Front()
+	for node != nil {
+		cycleArr := strings.Split(node.Value.(string), " --> ") // get the array of strings
+		cycleArr = cycleArr[0 : len(cycleArr)-1]                // cut off the end
+		for _, table := range cycleArr {
+			_, exists := m[table]
+			// unnecessary but it makes more sense this way
+			if !exists {
+				m[table] = 1
+			} else {
+				m[table] = m[table] + 1
+			}
+		}
+		node = node.Next() // move to the next node
+	}
+	return m
+}
+func getMostMentioned(fmap map[string]int) string {
+	var k string
+	var v int
+	// loop over the map
+	for key, value := range fmap {
+		if value > v { // check if the value of the current key is greater than current
+			k = key   // set the new key
+			v = value // set the new value
+		}
+	}
+	return k
+}
+func (tl *Ordering) CycleBreaking(cycles *list.List) *list.List {
+	tables := list.New()
+	tablesMap := getTablesMap(cycles) // a map that stores which tables are in each cycle
+	for cycles.Len() > 0 {
+		tablesMentioned := getFrequency(cycles)            // we get a map of tables and how often they appear
+		mostMentioned := getMostMentioned(tablesMentioned) // get the problem table
+		tables.PushBack(mostMentioned)                     // add the most mentioned to the list
+		node := cycles.Front()
+		for node != nil {
+			nextNode := node.Next()
+			// if the most mentioned is in this node, remove the node from the list
+			if tablesMap[node.Value.(string)][mostMentioned] {
+				cycles.Remove(node)
+			}
+			node = nextNode // move to the next node
+		}
+	}
+	return tables
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/Keith1039/Capstone_Test/db"
+	"github.com/Keith1039/Capstone_Test/graph"
 	"github.com/Keith1039/Capstone_Test/parameters"
 )
 
@@ -9,14 +11,56 @@ func main() {
 
 	writer := parameters.QueryWriter{TableName: "students"}
 	err := writer.Init()
+	//writer := parameters.QueryWriter{TableName: "students"}
+	//err := writer.Init()
+	//if err != nil {
+	//	panic(err)
+	//}
+	//writer.ProcessTables()
+	//e := writer.InsertQueryQueue.Front()
+	//for e != nil {
+	//	fmt.Println(e.Value.(string))
+	//	e = e.Next()
+	//}
+	var ord graph.Ordering
+	var queryWriter parameters.QueryWriter
+
+	ord.Init()
+	queryWriter.TableName = "b"
+	queryWriter.Init()
+
+	fmt.Println("Detecting cycles....")
+	cycles := ord.HasCycles()
+	node := cycles.Front()
+	for node != nil {
+		fmt.Println(fmt.Sprintf("cycle detected: %s", node.Value.(string)))
+		node = node.Next()
+	}
+	fmt.Println("Generating queries to break cycle while maintaining relationships...")
+	problemTables := ord.CycleBreaking(cycles)
+	queries := queryWriter.CreateSuggestions(problemTables) // create the suggestions
+	node = queries.Front()
+	i := 1
+	// print out the queries
+	for node != nil {
+		fmt.Println(fmt.Sprintf("query %d: %s", i, node.Value.(string)))
+		i++
+		node = node.Next()
+	}
+	fmt.Println("Running queries...")
+	err = db.RunQueries(queries) // run the queries
 	if err != nil {
 		panic(err)
+	} else {
+		fmt.Println("Finished running queries!")
 	}
-	writer.ProcessTables()
-	e := writer.InsertQueryQueue.Front()
-	for e != nil {
-		fmt.Println(e.Value.(string))
-		e = e.Next()
+	fmt.Println("Checking if cycles still exist...")
+	ord.Init()               // reset the maps
+	cycles = ord.HasCycles() // check for cycles
+	if cycles.Len() == 0 {
+		fmt.Println("No cycles found!")
+	} else {
+		fmt.Println("Cycles found! Guess this didn't work...")
 	}
 
 }

--- a/parameters/query_writer.go
+++ b/parameters/query_writer.go
@@ -84,6 +84,37 @@ func (qw *QueryWriter) ProcessTable() {
 	qw.TableOrderQueue.Remove(qw.TableOrderQueue.Front()) // remove the first in the queue
 }
 
+func (qw *QueryWriter) CreateSuggestions(cycles *list.List) *list.List {
+	var builder strings.Builder
+	inverseRelationships := db.CreateInverseRelationships()
+	queries := list.New()
+	node := cycles.Front()
+	for node != nil {
+		refTable := node.Value.(string)
+		tableRelations := inverseRelationships[refTable]
+		colMap := db.GetRawColumnMap(refTable)
+		for problemTable, relation := range tableRelations {
+			refColMap := db.GetRawColumnMap(problemTable)
+			// first format the string to get rid of the reference column
+			queries.PushBack(fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s;", problemTable, relation["FKColumn"]))
+			query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s_%s(\n", refTable, problemTable)
+			builder.WriteString(query)
+			query = fmt.Sprintf("\t %s %s,\n\t %s %s, ", refTable+"_ref", colMap[relation["Column"]], problemTable+"_ref", refColMap[qw.pkMap[problemTable]])
+			builder.WriteString(query)
+			query = fmt.Sprintf("\n\tFOREIGN KEY (%s) REFERENCES %s,", refTable+"_ref", refTable)
+			builder.WriteString(query)
+			query = fmt.Sprintf("\n\tFOREIGN KEY (%s) REFERENCES %s,", problemTable+"_ref", problemTable)
+			builder.WriteString(query)
+			query = fmt.Sprintf("\n\tPRIMARY KEY (%s, %s)\n)", refTable+"_ref", problemTable+"_ref")
+			builder.WriteString(query)
+			queries.PushBack(builder.String())
+			builder.Reset()
+		}
+		node = node.Next()
+	}
+	return queries
+}
+
 func createTable(tableName string) table {
 	t := table{TableName: tableName}
 	columnMap := db.GetColumnMap(tableName)


### PR DESCRIPTION
This series of changes is meant to support the program creating suggestion queries to resolve database cycles. The following changes help in enabling that.

Changes for the `db` package:
- `GetRawColumnMap()`: This function takes in a table name and returns the column names mapped to their respective type. This is used when creating new columns based on the old ones. Unlike the `GetColumnMap()` function, this one doesn't do any "translation" because it doesn't need to interact with the parsers. The function then returns that map. This function also doesn't perform any checks on the given database name because it's parent functions do that for it.

- `CreateInverseRelationships()`: This function is the inverse of the `CreateRelationships()` function. Instead of mapping a table to a map of the columns, to a map of the referenced table and referenced column it does the inverse. Meaning, it maps a table to the tables that reference it, to a map of the referenced column and column of the original table. It then returns that map

For example, say we have a table A that references table B, which has the primary key bkey, with the column b_ref, the map would look like this. [B: A["Column": bkey, "FKColumn": b_ref]]

- `RunQueries()`: This function takes in a list of queries and returns an error if executing those queries fails. Considering that each of the queries depends on it's previous query, this error should be panicked when returned.

Changes for the `graph` package:
- `HasCycles()`: Fixed a bug in the code where instead of appending the list to the list of cycles, it appended the entire list into the next node.

- `findCycles()`: This function now takes in the map of topological nodes (map[string]*TopologicalNodes) as well as the table name. This is because both the `hasCyclesForTable()` function and `HasCycles()` function depends on it. As a result, it would redo previous work by creating a new topological nodes map if it was ran multiple times. This is, of course, wasteful so instead it takes in an existing map to know which paths have already been explored.

- `getTablesMap()`: This function takes in a list of cyclic strings delimited by " --> " and creates a map of each cycle and maps them to a map of table names in the cyclic string. This makes it easy to remove "solved cycles" in the list. It then returns this map.

- `getFrequency()`: This function takes in a list of cyclic strings delimited by " --> " and creates a map of each table that appears mapped to how many cycles they are a part of. This function cuts off the end of the string array gotten from splitting the cyclic string using " --> " otherwise it would count the starting node twice. It then returns that map.

- `getMostMentioned()`: This function takes in the frequency map generated by `getFrequency()` and sorts the keys based on their value in descending order. It then returns the name of the table that appeared in the most cycles.

- `Cyclebreaking()`: This function takes in a list of cyclic strings delimited by " --> " and returns a list of tables that you need to 'get rid of' in that specific order to resolve all cycles.

Changes to the `parameters` package:
- `CreateSuggestions()`: This function takes in a list of  the problem tables and creates a series of queries to break off the cyclical dependency by creating a reference table based on the two tables. For example, if there was a cyclic dependancy like this "A --> B --> C --> A" we could break it with the following queries (not exact sql btw). ALTER TABLE IF EXISTS C DROP COLUMN (AREF);
CREATE TABLE IF EXISTS A_C (
	AREF INT,
	CREF INT,
	FOREIGN KEY (AREF) REFERENCES A,
	FOREIGN KEY (CREF) REFERENCES C,
	PRIMARY KEY(AREF, CREF)
)