### PR TITLE
Task 5.1: Housekeeping and Bugfixing

### DIFF
--- a/graph/node.go
+++ b/graph/node.go
@@ -1,6 +1,6 @@
 package graph
 
-type TopologicalNode struct {
+type topologicalNode struct {
 	TableName     string
 	path          string
 	RelatedTables []string
@@ -9,19 +9,8 @@ type TopologicalNode struct {
 	completed     bool
 }
 
-type OrderInfoNode struct {
-	tableName       string
-	parentTableName string
-}
-
-type TableNode struct {
-	TableName  string
-	ColumnData map[string]string
-	Parameters map[string]string
-}
-
-func GetTopologicalNodes(allTables map[string]int, allRelations map[string]map[string]map[string]string) map[string]*TopologicalNode {
-	m := make(map[string]*TopologicalNode) // map of the table names tied to the node
+func getTopologicalNodes(allTables map[string]int, allRelations map[string]map[string]map[string]string) map[string]*topologicalNode {
+	m := make(map[string]*topologicalNode) // map of the table names tied to the node
 	for tableName := range allTables {
 		relations, exists := allRelations[tableName]
 		if exists {
@@ -36,10 +25,10 @@ func GetTopologicalNodes(allTables map[string]int, allRelations map[string]map[s
 				arr[slider] = key
 				slider++
 			}
-			node := &TopologicalNode{TableName: tableName, RelatedTables: arr}
+			node := &topologicalNode{TableName: tableName, RelatedTables: arr}
 			m[tableName] = node
 		} else {
-			m[tableName] = &TopologicalNode{TableName: tableName, completed: true}
+			m[tableName] = &topologicalNode{TableName: tableName, completed: true}
 		}
 	}
 	return m

--- a/graph/ordering_test.go
+++ b/graph/ordering_test.go
@@ -79,7 +79,7 @@ func TestOrdering_FindOrderCase1(t *testing.T) {
 	}
 	ordering := Ordering{}
 	ordering.Init()
-	order, err := ordering.FindOrder("a")
+	order, err := ordering.GetOrder("a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestOrdering_FindOrderCase2(t *testing.T) {
 
 	ordering := Ordering{}
 	ordering.Init()
-	_, err = ordering.FindOrder("team_members")
+	_, err = ordering.GetOrder("team_members")
 	properError := errors.As(err, &cyclicError)
 	if !properError || err == nil {
 		t.Errorf("Cyclic error not detected between tables teams and students")
@@ -135,7 +135,7 @@ func TestOrdering_FindOrderCase3(t *testing.T) {
 
 	ordering := Ordering{}
 	ordering.Init()
-	order, err := ordering.FindOrder("users")
+	order, err := ordering.GetOrder("users")
 	if err != nil {
 		t.Errorf("Unexpected Error: %s", err.Error())
 	} else if order.Front().Value.(string) != "users" {
@@ -152,7 +152,7 @@ func TestOrdering_FindOrderCase4(t *testing.T) {
 	}
 	ordering := Ordering{}
 	ordering.Init()
-	order, err := ordering.FindOrder("team_members")
+	order, err := ordering.GetOrder("team_members")
 	if err == nil {
 		t.Fatal("Missing table error should have occurred")
 	}

--- a/main.go
+++ b/main.go
@@ -30,14 +30,14 @@ func main() {
 	queryWriter.Init()
 
 	fmt.Println("Detecting cycles....")
-	cycles := ord.HasCycles()
+	cycles := ord.GetCycles()
 	node := cycles.Front()
 	for node != nil {
 		fmt.Println(fmt.Sprintf("cycle detected: %s", node.Value.(string)))
 		node = node.Next()
 	}
 	fmt.Println("Generating queries to break cycle while maintaining relationships...")
-	problemTables := ord.CycleBreaking(cycles)
+	problemTables := ord.GetCycleBreakingOrder(cycles)
 	queries := queryWriter.CreateSuggestions(problemTables) // create the suggestions
 	node = queries.Front()
 	i := 1
@@ -56,7 +56,7 @@ func main() {
 	}
 	fmt.Println("Checking if cycles still exist...")
 	ord.Init()               // reset the maps
-	cycles = ord.HasCycles() // check for cycles
+	cycles = ord.GetCycles() // check for cycles
 	if cycles.Len() == 0 {
 		fmt.Println("No cycles found!")
 	} else {

--- a/parameters/query_writer.go
+++ b/parameters/query_writer.go
@@ -27,7 +27,7 @@ func (qw *QueryWriter) Init() error {
 	qw.AllRelations = db.CreateRelationships()
 	qw.pkMap = db.GetTablePKMap()
 	qw.SetFKMap()
-	qw.TableOrderQueue, err = ordering.FindOrder(qw.TableName) // get the topological ordering of tables
+	qw.TableOrderQueue, err = ordering.GetOrder(qw.TableName) // get the topological ordering of tables
 	qw.InsertQueryQueue = list.New()
 	qw.DeleteQueryQueue = list.New()
 	return err


### PR DESCRIPTION
This series of commits doesn't provide any new functionality or features, instead it focuses on renaming and refining existing code.

The following functions received name changes:
- `HasCycles()` --> `GetCycles()`
- `hasCyclesForTable()` --> `getCyclesForTable()`
- `FindOrder()` --> `GetOrder()`
- `CycleBreaking()` --> `GetCycleBreakingOrder()`

As a consequence all references to these functions needed to be edited.

a series of functions and structs became private because they really don't need to be used outside their package.