### PR TITLE
Task 5.2: Further Refining the Code

### DIFF
--- a/graph/ordering.go
+++ b/graph/ordering.go
@@ -2,9 +2,17 @@ package graph
 
 import (
 	"container/list"
+	"fmt"
 	"github.com/Keith1039/Capstone_Test/db"
 	"strings"
 )
+
+func NewOrdering() *Ordering {
+	// get a new ordering
+	ord := Ordering{}
+	ord.Init()
+	return &ord
+}
 
 type Ordering struct {
 	allTables    map[string]int
@@ -201,4 +209,36 @@ func (tl *Ordering) GetCycleBreakingOrder(cycles *list.List) *list.List {
 		}
 	}
 	return tables
+}
+
+func (tl *Ordering) CreateSuggestions(cycles *list.List) *list.List {
+	var builder strings.Builder
+	inverseRelationships := db.CreateInverseRelationships()
+	queries := list.New()
+	node := cycles.Front()
+	pkMap := db.GetTablePKMap()
+	for node != nil {
+		refTable := node.Value.(string)
+		tableRelations := inverseRelationships[refTable]
+		colMap := db.GetRawColumnMap(refTable)
+		for problemTable, relation := range tableRelations {
+			refColMap := db.GetRawColumnMap(problemTable)
+			// first format the string to get rid of the reference column
+			queries.PushBack(fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s;", problemTable, relation["FKColumn"]))
+			query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s_%s(\n", refTable, problemTable)
+			builder.WriteString(query)
+			query = fmt.Sprintf("\t %s %s,\n\t %s %s, ", refTable+"_ref", colMap[relation["Column"]], problemTable+"_ref", refColMap[pkMap[problemTable]])
+			builder.WriteString(query)
+			query = fmt.Sprintf("\n\tFOREIGN KEY (%s) REFERENCES %s,", refTable+"_ref", refTable)
+			builder.WriteString(query)
+			query = fmt.Sprintf("\n\tFOREIGN KEY (%s) REFERENCES %s,", problemTable+"_ref", problemTable)
+			builder.WriteString(query)
+			query = fmt.Sprintf("\n\tPRIMARY KEY (%s, %s)\n)", refTable+"_ref", problemTable+"_ref")
+			builder.WriteString(query)
+			queries.PushBack(builder.String())
+			builder.Reset()
+		}
+		node = node.Next()
+	}
+	return queries
 }


### PR DESCRIPTION
This series of changes is meant to make the code more easily used as a library. This involves helper functions to make a proper `Ordering` and `QueryWriter` structs. The `CreateSuggestions()` function was moved back to the `Ordering` struct because a `QueryWriter` should not be able to be made if there is a cycle in the path for the given table.

Helper Functions Made:
- `NewOrdering()`: returns the pointer to a `Ordering` struct that has ran the `Init` function
- `NewQueryWriterFor()`: This function takes in a table name and returns the pointer to the `QueryWriter` and any errors
- `ChangeTableToWriteFor()`: Takes in a table name and reinitializes the `QueryWriter` struct. It returns any errors from the `Init()` call.

Other changes:
- `allRelations` in the `QueryWriter` struct is now private
- updated the main file